### PR TITLE
Fix go.mod

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thank you for helping to improve Crossplane!
+
+Please read through https://git.io/fj2m9 if this is your first time opening a
+Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
+you need any help contributing.
+-->
+
+### Description of your changes
+
+<!--
+Briefly describe what this pull request does. Be sure to direct your reviewers'
+attention to anything that needs special consideration.
+
+We love pull requests that resolve an open Crossplane issue. If yours does, you
+can uncomment the below line to indicate which issue your PR fixes, for example
+"Fixes #500":
+
+-->
+Fixes #
+
+I have:
+
+- [ ] Read and followed Crossplane's [contribution process].
+- [ ] Run `make reviewable test` to ensure this PR is ready for review.
+
+### How has this code been tested
+
+<!--
+Before reviewers can be confident in the correctness of this pull request, it
+needs to tested and shown to be correct. Briefly describe the testing that has
+already been done or which is planned for this change.
+-->
+
+[contribution process]: https://git.io/fj2m9

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ crds.clean:
 	@find package/crds -name *.yaml.sed -delete || $(FAIL)
 	@$(OK) cleaned generated CRDs
 
-generate: crds.clean
+generate.done: crds.clean
 
 # integration tests
 e2e.run: test-integration

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crossplane-contrib/provider-civo
 go 1.16
 
 require (
-	github.com/civo/civogo v0.2.47 // indirect
+	github.com/civo/civogo v0.2.47
 	github.com/crossplane/crossplane-runtime v0.13.0
 	github.com/crossplane/crossplane-tools v0.0.0-20201201125637-9ddc70edfd0d
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -17,7 +17,7 @@ require (
 	golang.org/x/tools v0.1.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	k8s.io/api v0.20.1 // indirect
+	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1
 	k8s.io/client-go v0.20.1
 	sigs.k8s.io/controller-runtime v0.8.0


### PR DESCRIPTION
Updates go.mod so that check-diff does not fail in CI.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

