### PR TITLE
update 'make localdev' script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,10 @@ run: $(KUBECTL) generate
 	@$(INFO) Running Crossplane locally out-of-cluster . . .
 	@$(KUBECTL) apply -f package/crds/ -R
 	go run cmd/provider/main.go -d
-
+localdev: ## Run local development script with specified command
+	./scripts/local.sh $(filter-out $@,$(MAKECMDGOALS))
+%:
+	@:	
 manifests:
 	@$(INFO) Deprecated. Run make generate instead.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ Please use the following to reach members of the community:
 
 provider-civo adheres to the same [Code of Conduct](https://github.com/crossplane/crossplane/blob/master/CODE_OF_CONDUCT.md) as the core Crossplane project.
 
-## Usage
+## Run it locally
+
+In the development phase you can test your changes on the `crossplane-civo-provider` via its facility script:
+```bash
+~ (crossplane-civo-provider) $ make localdev
+```
+By using its subcommand `init` you will get a civo kubernetes cluster up and running in a production region of your choice. This cluster will be hosting the Crossplane CRDs (Custom Resource Definition) for Civo (for example `CivoKubernetes`).
+To generate and install the new CRDs from the `crossplane-civo-provider` codebase you can use the subcommand `update`. 
+Once they're installed, the above command will run the `crossplane-civo-provider` locally in background and will connect to the newly created cluster.
+The `example` subcommand will return an example to connect to the `crossplane-master` cluster and to deploy a `CivoKubernetes` CR.
+This will trigger the creation of another cluster in the destination region you specified.
 
 ### Prerequisites
 

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -41,7 +41,7 @@ if [ "$1" == "init" ]; then
    fi
    
    # wait the master cluster to be ready
-   while [ -z "`civo kube ls --region=${source_region} | grep crossplane-master | grep ACTIVE`" ]
+   while [ -z "`civo kube show crossplane-master --region=${source_region} | grep 'Status : ACTIVE'`" ]
    do
       printf "."
       sleep 5
@@ -112,13 +112,14 @@ metadata:
   name: hello-crossplane
 spec:
   name: hello-crossplane
+  version: 1.26.4-k3s1
   pools:
   - id: "8382e422-dcdd-461f-afb4-2ab67f171c3e"
     count: 2
-    size: g3.k3s.small
+    size: g4s.kube.xsmall
   - id: "8482f422-dcdd-461g-afb4-2ab67f171c3e"
     count: 1
-    size: g3.k3s.small
+    size: g4s.kube.small
   connectionDetails:
     connectionSecretNamePrefix: "cluster-details"
     connectionSecretNamespace: "default"


### PR DESCRIPTION
### Description of your changes

This MR updates the `make localdev` script used to test any changes to the provider by running crossplane on your local machine.

This MR fixes some incompatibility due to the recent Civo updates on CLI and on Kubernetes spec.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This code doesn't impact on the provider logic, but provides some facility scripts to ease the development and test of the changes for the developer.

[contribution process]: https://git.io/fj2m9
